### PR TITLE
Explicitly configure a Python 3 interpreter in host file

### DIFF
--- a/hosts
+++ b/hosts
@@ -7,6 +7,7 @@
 release=el7
 arch=x86_64
 extension=rpm
+ansible_python_interpreter=/usr/bin/python3
 
 ########################## Debian #######################
 
@@ -15,12 +16,14 @@ extension=rpm
 
 [Debian_8:vars]
 release=debian-8
+ansible_python_interpreter=/usr/bin/python3
 
 [Debian_9]
 10.11.0.2
 
 [Debian_9:vars]
 release=debian-9
+ansible_python_interpreter=/usr/bin/python3
 
 [Debian:children]
 Debian_8
@@ -29,6 +32,7 @@ Debian_9
 [Debian:vars]
 arch=amd64
 extension=deb
+ansible_python_interpreter=/usr/bin/python3
 
 ########################## Ubuntu ##########################
 
@@ -37,12 +41,14 @@ extension=deb
 
 [Ubuntu_16:vars]
 release=ubuntu-1604
+ansible_python_interpreter=/usr/bin/python3
 
 [Ubuntu_18]
 10.12.0.2
 
 [Ubuntu_18:vars]
 release=ubuntu-1804
+ansible_python_interpreter=/usr/bin/python3
 
 [Ubuntu:children]
 Ubuntu_16
@@ -51,6 +57,7 @@ Ubuntu_18
 [Ubuntu:vars]
 arch=amd64
 extension=deb
+ansible_python_interpreter=/usr/bin/python3
 
 
 ########################## SUSE ##########################
@@ -62,6 +69,7 @@ extension=deb
 release=el7
 arch=x86_64
 extension=rpm
+ansible_python_interpreter=/usr/bin/python3
 
 ########################## RedHat ##########################
 
@@ -72,6 +80,7 @@ extension=rpm
 release=el7
 arch=x86_64
 extension=rpm
+ansible_python_interpreter=/usr/bin/python3
 
 ########################## Linux Group ##########################
 


### PR DESCRIPTION
Gets rid of the warning

`[DEPRECATION WARNING]: Distribution Ubuntu 18.04 on host should use /usr/bin/python3, but is using /usr/bin/python for backward compatibility with prior Ansible releases.`

Documentation: https://docs.ansible.com/ansible/latest/reference_appendices/python_3_support.html